### PR TITLE
Add wrap function

### DIFF
--- a/xerrors/example_test.go
+++ b/xerrors/example_test.go
@@ -1,0 +1,77 @@
+package werror_test
+
+import (
+	"fmt"
+	"os"
+
+	werror "github.com/sonatard/werror/xerrors"
+	"golang.org/x/xerrors"
+)
+
+type ApplicationError struct {
+	level string
+	code  int
+	msg   string
+	werror.WrapError
+}
+
+func (e *ApplicationError) Wrap(wraperr error) error {
+	newerr := *e
+	newerr.WrapError = werror.Wrap(e, wraperr)
+	return &newerr
+}
+
+func (e *ApplicationError) Error() string {
+	return fmt.Sprintf("%s: code=%d, msg=%s", e.level, e.code, e.msg)
+}
+
+func Example() {
+	// NOTE: We define ApplicationError like the comment below.
+	// (We show this as a comment since we cannot define methods in a function)
+	//
+	// type ApplicationError struct {
+	//     level string
+	//     code  int
+	//     msg   string
+	//     werror.WrapError
+	// }
+	//
+	// func (e *ApplicationError) Wrap(wraperr error) error {
+	//     newerr := *e
+	//     newerr.WrapError = werror.Wrap(e, wraperr)
+	//     return &newerr
+	// }
+	//
+	// func (e *ApplicationError) Error() string {
+	//     return fmt.Sprintf("%s: code=%d, msg=%s", e.level, e.code, e.msg)
+	// }
+
+	var ErrUserNotFound = &ApplicationError{
+		code:  101,
+		level: "Error",
+		msg:   "not found",
+	}
+
+	a := func() error {
+		return xerrors.New("error in a")
+	}
+
+	err := ErrUserNotFound.Wrap(a())
+	fmt.Fprintf(os.Stderr, "caught error: %+v\n", err)
+
+	// NOTE: The some output like below will be printed to stderr,
+	// but we cannot use this as expected test result since the full path
+	// will be different when this example runs in a different directory.
+	//
+	// caught error: Error: code=101, msg=not found:
+	//    github.com/sonatard/werror_test.Example
+	//        /tmp/go/src/github.com/sonatard/werror/example_test.go:59
+	//  - error in a:
+	//    github.com/sonatard/werror_test.Example.func1
+	//        /tmp/go/src/github.com/sonatard/werror/example_test.go:56
+
+	// NOTE: Below "Output:" is needed to run this example as a test by
+	// go test -v
+
+	// Output:
+}

--- a/xerrors/example_test.go
+++ b/xerrors/example_test.go
@@ -17,7 +17,7 @@ type ApplicationError struct {
 
 func (e *ApplicationError) Wrap(wraperr error) error {
 	newerr := *e
-	newerr.WrapError = werror.Wrap(e, wraperr)
+	newerr.WrapError = *werror.Wrap(e, wraperr, 2)
 	return &newerr
 }
 

--- a/xerrors/werror.go
+++ b/xerrors/werror.go
@@ -12,6 +12,14 @@ type WrapError struct {
 	Frame xerrors.Frame
 }
 
+func Wrap(wraperr error, cause error) WrapError {
+	var newerr WrapError
+	newerr.Msg = wraperr.Error()
+	newerr.Frame = xerrors.Caller(2)
+	newerr.Err = cause
+	return newerr
+}
+
 func (e *WrapError) Error() string {
 	return e.Msg
 }

--- a/xerrors/werror.go
+++ b/xerrors/werror.go
@@ -12,12 +12,12 @@ type WrapError struct {
 	Frame xerrors.Frame
 }
 
-func Wrap(wraperr error, cause error) WrapError {
-	var newerr WrapError
-	newerr.Msg = wraperr.Error()
-	newerr.Frame = xerrors.Caller(2)
-	newerr.Err = cause
-	return newerr
+func Wrap(wraperr error, cause error, calldepth int) *WrapError {
+	return &WrapError{
+		Msg:   wraperr.Error(),
+		Err:   cause,
+		Frame: xerrors.Caller(calldepth),
+	}
 }
 
 func (e *WrapError) Error() string {


### PR DESCRIPTION
Hi, I modified the example in [xerrors パッケージで途中に独自定義したエラー型をラップする方法 - Qiita](https://qiita.com/sonatard/items/e0f866f44717c0501f7a) by adding `Wrap` method to `WrapError` and `ApplicationError`.
Could you review this?

If you like this, this pull request should be merged after https://github.com/sonatard/werror/pull/3
Thanks!
